### PR TITLE
Fix missing ESCAPED_DQ File Format

### DIFF
--- a/remote_flow/metaflow/data_processing/connectors/sf_connector.py
+++ b/remote_flow/metaflow/data_processing/connectors/sf_connector.py
@@ -74,6 +74,10 @@ class SFSelfClosingNamespaceConnection:
         self._cs.executemany(command, seq_of_parameters)
 
     def upload_file(self, absolute_file_path, table):
+        self._cs.execute(f"CREATE OR REPLACE FILE FORMAT ESCAPED_DQ TYPE = CSV "
+                         "RECORD_DELIMITER = '\\n' "
+                         "FIELD_OPTIONALLY_ENCLOSED_BY = '\\\"' "
+                         "COMMENT = 'for loading objects from csv'")
         self._cs.execute(f"PUT file://{absolute_file_path} @%{table}")
         self._cs.execute(f"COPY INTO {table} "
                          "FILE_FORMAT = ESCAPED_DQ")


### PR DESCRIPTION
The definition of the custom ESCAPED_DQ file format is missing on the sf_connector file, causing issues when a user is trying to upload the data into Snowflake.

Original issue: https://github.com/jacopotagliabue/you-dont-need-a-bigger-boat/issues/6